### PR TITLE
Display total price in the navbar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+
+  def current_order
+    Order.find(session[:order_id])
+  end
 end

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -24,7 +24,7 @@
         <ul class="navbar-nav ml-auto">
             <li class="nav-item">
               <% if session[:order_id] %>
-                <%= link_to 'Checkout', order_path(session[:order_id]), class: 'glyphicon glyphicon-shopping-cart', id: "order-icon" %>
+                <%= link_to " #{current_order.total} Checkout", order_path(session[:order_id]), class: 'glyphicon glyphicon-shopping-cart', id: "order-icon" %>
               <% end %>
             </li>
         </ul>

--- a/features/display_total_price_in_the_navbar.feature
+++ b/features/display_total_price_in_the_navbar.feature
@@ -17,13 +17,13 @@ Feature: Visitor can see total price in the navbar
       | Pizza   |
 
     And the following products exist for "Pizza"
-      | name       | price  |
-      | Margherita | 15     |
-      | Hawaii     | 14     |
+      | name       | price     |
+      | Margherita | 15        |
+      | Hawaii     | 14        |
 
     Scenario: Visitor can add a selected product to an order
       Given I visit the "ThaiTanic" page
       When I click on "Add to Order" for "Margherita"
-      Then I should see 15 in the navbar
+      Then I should see 16.24 in the navbar
       And I click on "Add to Order" for "Hawaii"
-      Then I should see 24 in the navbar
+      Then I should see 31.39 in the navbar

--- a/features/display_total_price_in_the_navbar.feature
+++ b/features/display_total_price_in_the_navbar.feature
@@ -1,0 +1,29 @@
+Feature: Visitor can see total price in the navbar
+  As a visitor
+  In order to keep track of the total amount of my order
+  I would like the navbar checkout icon to be updated with the total price
+
+  Background:
+    Given the following restaurants exists
+      | name            | description                                      |
+      | ThaiTanic       | Thailands finest food, watch out for the iceberg |
+
+    And the following menus exist for "ThaiTanic"
+      | name    |
+      | Lunch   |
+
+    And the following product categories exist for "Lunch"
+      | name    |
+      | Pizza   |
+
+    And the following products exist for "Pizza"
+      | name       | price  |
+      | Margherita | 15     |
+      | Hawaii     | 14     |
+
+    Scenario: Visitor can add a selected product to an order
+      Given I visit the "ThaiTanic" page
+      When I click on "Add to Order" for "Margherita"
+      Then I should see 15 in the navbar
+      And I click on "Add to Order" for "Hawaii"
+      Then I should see 24 in the navbar

--- a/features/step_definitions/order_steps.rb
+++ b/features/step_definitions/order_steps.rb
@@ -28,3 +28,7 @@ And(/^"([^"]*)" is already in my order$/) do |product_name|
    And I should be on the restaurant "ThaiTanic" page
         }
 end
+
+Then("I should see {int} in the navbar") do |int|
+
+end

--- a/features/step_definitions/order_steps.rb
+++ b/features/step_definitions/order_steps.rb
@@ -29,6 +29,8 @@ And(/^"([^"]*)" is already in my order$/) do |product_name|
         }
 end
 
-Then("I should see {int} in the navbar") do |int|
-
+Then("I should see {float} in the navbar") do |float|
+  within('div#collapsing-navbar') do
+    expect(page).to have_content float
+  end
 end


### PR DESCRIPTION
## PT-Link: https://www.pivotaltracker.com/story/show/154203554

### Description
Once a visitor selects a product the navbar checkout will update with the total amount (incl. tax), this will help the visitor keep track of their order and the total price.

### Screenshot
<img width="767" alt="screen shot 2018-01-22 at 09 52 27" src="https://user-images.githubusercontent.com/28058646/35212322-0820cd4e-ff5a-11e7-8acd-8e14238da7ad.png">


